### PR TITLE
attention augmented block should use BatchNorm

### DIFF
--- a/attn_augconv.py
+++ b/attn_augconv.py
@@ -1,5 +1,6 @@
 from keras.layers import Layer
 from keras.layers import Conv2D
+from keras.layers import BatchNormalization
 from keras.layers import concatenate
 
 from keras import initializers
@@ -304,6 +305,7 @@ def augmented_conv2d(ip, filters, kernel_size=(3, 3), strides=(1, 1),
     attn_out = _conv_layer(depth_v, kernel_size=(1, 1))(attn_out)
 
     output = concatenate([conv_out, attn_out], axis=channel_axis)
+    output = BatchNormalization()(output)
     return output
 
 


### PR DESCRIPTION
From the [paper](https://arxiv.org/pdf/1904.09925.pdf):
> In all our experiments, the augmented convolution is followed by a batch normalization [20] layer which can learn to scale the contribution of the convolution feature maps and the attention feature maps

This commit adds a Keras BatchNormalization layer to the output of an augmented conv2d block.